### PR TITLE
Added ami-id and instance-type to support cloudwatchmon python module.

### DIFF
--- a/ectou_metadata/service.py
+++ b/ectou_metadata/service.py
@@ -62,8 +62,10 @@ def latest():
 
 @bottle.route("/latest/meta-data/")
 def meta_data():
-    return _index(["iam/",
+    return _index(["ami-id",
+                   "iam/",
                    "instance-id",
+                   "instance-type",
                    "local-ipv4",
                    "placement/",
                    "public-hostname",
@@ -126,6 +128,15 @@ def instance_id():
     bottle.response.content_type = 'text/plain'
     return "i-deadbeef"
 
+@bottle.route("/latest/meta-data/instance-type")
+def instance_id():
+    bottle.response.content_type = 'text/plain'
+    return "m4.large"
+
+@bottle.route("/latest/meta-data/ami-id")
+def instance_id():
+    bottle.response.content_type = 'text/plain'
+    return "ami-00000042"
 
 @bottle.route("/latest/meta-data/local-ipv4")
 def local_ipv4():

--- a/ectou_metadata/service.py
+++ b/ectou_metadata/service.py
@@ -128,15 +128,18 @@ def instance_id():
     bottle.response.content_type = 'text/plain'
     return "i-deadbeef"
 
+
 @bottle.route("/latest/meta-data/instance-type")
 def instance_id():
     bottle.response.content_type = 'text/plain'
-    return "m4.large"
+    return "m4.deadbeef"
+
 
 @bottle.route("/latest/meta-data/ami-id")
 def instance_id():
     bottle.response.content_type = 'text/plain'
-    return "ami-00000042"
+    return "ami-deadbeef"
+
 
 @bottle.route("/latest/meta-data/local-ipv4")
 def local_ipv4():


### PR DESCRIPTION
Using cloudwatchmon to report statistics didn't work on local vagrant nodes because it includes ami-id and instance-type as dimensions when reporting to cloudwatch.  This adds those urls to the metadata service, returning bogus values of m4.large and 'ami-0000042'.
